### PR TITLE
Fetch items within package

### DIFF
--- a/geem/views.py
+++ b/geem/views.py
@@ -10,6 +10,7 @@ import re, os
 from rest_framework import mixins
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import action
 from oauth2_provider.contrib.rest_framework import TokenHasReadWriteScope, TokenHasScope, OAuth2Authentication
 from rest_framework import viewsets, permissions
 from django.shortcuts import get_object_or_404
@@ -78,6 +79,29 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
         package = get_object_or_404(queryset, pk=pk)  # OR .get(pk=1) ???
         return Response(ResourceDetailSerializer(package, context={'request': request}).data)
 
+    @action(detail=True)
+    def specifications(self, request, pk=None):
+        """Get entire specifications, or a single term, from a package.
+
+        * api/resources/{pk}/specifications
+
+          * Specifications of package with id == {pk}
+
+        * api/resources/{pk}/specifications/?id={id}
+
+          * Filter specifications field with id == {id}
+
+        TODO:
+
+        * Only display packages user has access to
+        """
+        id_query_parameter = request.query_params.get('id', None)
+        if id_query_parameter is None:
+            query = 'contents__specifications'
+        else:
+            query = 'contents__specifications__' + id_query_parameter
+        queryset= Package.objects.filter(pk=pk).values(query)
+        return Response(list(queryset)[0])
 
     def create(self, request, pk=None):
 

--- a/geem/views.py
+++ b/geem/views.py
@@ -80,28 +80,27 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
         package = get_object_or_404(queryset, pk=pk)  # OR .get(pk=1) ???
         return Response(ResourceDetailSerializer(package, context={'request': request}).data)
 
-    @action(detail=True)
-    def specifications(self, request, pk=None):
+    @action(detail=True, url_path='specifications(?:/(?P<id>[^/.]+))?')
+    def specifications(self, request, pk=None, id=None):
         """Get entire specifications, or a single term, from a package.
 
         * api/resources/{pk}/specifications
 
           * Specifications of package with id == {pk}
 
-        * api/resources/{pk}/specifications/?id={id}
+        * api/resources/{pk}/specifications/{id}
 
-          * Filter specifications field with id == {id}
+          * Get term from specifications with id == {id}
         """
         # Query package
         queryset = self._get_resource_queryset(request)
         queryset = queryset.filter(pk=pk)
 
         # Query entire specifications or exact term
-        id_query_parameter = request.query_params.get('id', None)
-        if id_query_parameter is None:
+        if id is None:
             query = 'contents__specifications'
         else:
-            query = 'contents__specifications__' + id_query_parameter
+            query = 'contents__specifications__' + id
         queryset = queryset.values(query)
 
         try:


### PR DESCRIPTION
@ddooley

I have investigated the possibility of fetching items from packages through the API, without loading the entire `specifications` field to JSON.

`api/resources/{pk}/specifications/?format=json` produces a JSON object containing the entire `specifications` field of a package with id `{pk}`.

`api/resources/{pk}/specifications/?format=json&id={id}` produces a JSON object containing a single term with with id `{id}` from the `specifications`. **This does not load the entire `specifications` to memory before filtering it down to one item.** Instead, it constructs a `QuerySet` for that specific item in the `specifications` JSON object. [`QuerySet` objects do not touch the database until they are actually evaluated](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#id1). In the context of this pull request, the `QuerySet` object is evaluated at [line 108 of geem/views.py](https://github.com/ivansg44/geem/blob/8934d816ceda2b02fd4cdc6b8b76d91a83d20d4b/geem/views.py#L108), which is after I have specified I only want one term extracted.

There is no "contained" way to add id to the URL in the shape of `api/resources/{pk}/specifications/{id}`. We would have to hard-code it into [api/urls.py](https://github.com/ivansg44/geem/blob/8934d816ceda2b02fd4cdc6b8b76d91a83d20d4b/api/urls.py#L12), as seen in the Django documentation [here](https://www.django-rest-framework.org/api-guide/filtering/#filtering-against-the-url). Let me know if having id as a query parameter is acceptable, or you want it hard-coded into a URL.