### PR TITLE
Add REST API CRUD (Create UPDATE Delete) actions to new specification API call

### DIFF
--- a/geem/views.py
+++ b/geem/views.py
@@ -151,7 +151,7 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
           * see https://code.djangoproject.com/ticket/29112
         """
         # Query specified package
-        queryset = self.get_modifiable_resources(request)
+        queryset = self.get_modifiable_packages(request)
         queryset = queryset.filter(pk=pk)
 
         # Unable to query any packages
@@ -215,7 +215,7 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
           * see https://code.djangoproject.com/ticket/29112
         """
         # Query specified package
-        queryset = self.get_modifiable_resources(request)
+        queryset = self.get_modifiable_packages(request)
         queryset = queryset.filter(pk=pk)
 
         # Unable to query any packages
@@ -365,8 +365,14 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
 
         return queryset.order_by('-ontology', 'public')
 
-    def get_modifiable_resources(self, request):
-        """Get queryset of resources user has permission to modify."""
+    def get_modifiable_packages(self, request):
+        """Get QuerySet of packages user has permission to modify.
+
+        :param rest_framework.request.Request request: Front-end
+                                                       request metadata
+        :return: Packages user has permission to modify
+        :rtype: QuerySet
+        """
         user = self.request.user
 
         if user.is_authenticated:

--- a/geem/views.py
+++ b/geem/views.py
@@ -226,15 +226,18 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
         except ValidationError:
             return Response('id must be a valid IRI',
                             content_type=status.HTTP_400_BAD_REQUEST)
-        # Validate 'id' key does not already exist in package
-        term_id_query = 'contents__specifications__' + term_id
-        if queryset.values(term_id_query)[0][term_id_query] is not None:
-            message = 'id %s already exists in package %s' % (term_id, pk)
-            return Response(message, content_type=status.HTTP_400_BAD_REQUEST)
+
         # Get a shortened version of term_id via a substitution prefix.
         # Add the substitution prefix to the package's context if
         # necessary.
         shortened_term_id = self._translate_iri(request, term_id, pk)
+
+        # Validate shortened 'id' key does not already exist in package
+        term_id_query = 'contents__specifications__' + shortened_term_id
+        if queryset.values(term_id_query)[0][term_id_query] is not None:
+            message = 'id %s already exists in package %s' % (term_id, pk)
+            return Response(message, content_type=status.HTTP_400_BAD_REQUEST)
+
         # Connect to the default database service
         with connection.cursor() as cursor:
             # See https://stackoverflow.com/a/23500670 for details on


### PR DESCRIPTION
Added the following API calls:

* `api/resources/{pk}/delete/specifications/`

  * Deletes all terms from specifications of package with id `{pk}`

  * Implemented in [`delete_specifications`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L133)

* `api/resources/{pk}/delete/specifications/{term_id}`

  * Deletes term with id `term_id` from specifications of package with id `{pk}`

  * Implemented in [`delete_specifications`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L133)

* `api/resources/{pk}/create/specifications/{term}`

  * Adds `{term}` to specifications of package with id `{pk}`

    * Term must be a `JSON` object

    * Term must have an `id` attribute

    * `id` attribute must be a full IRI

  * Implemented in [`create_specifications`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L185)

I implemented two private helper functions:

* [`_get_modifiable_packages`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L415)

  * Constructs `QuerySet` of packages user has permission to **modify**

  * Called in [`delete_specifications`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L133) and [`create_specifications`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L185), to prevent user from deleting or adding terms in packages they do not own

* [`_translate_iri`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L249)

  * Shortens an IRI through a substitution prefix

     * First looks for a substitution prefix in a specified package's `@context`

     * If none is present, attempts to create one and add it to the specified package's `@context`

  * Called in  [`create_specifications`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L185), where it shorten's the user-specified `id` in the term being added

I also renamed some variables and edited some comments for clarity.

The entire specifications of any package are not loaded into the user's browser through any of the changes I have implemented. Specific, targeted queries are executed on the backend at the following lines in [`views.py`](https://github.com/ivansg44/geem/blob/add_REST_API_CRUD/geem/views.py):

* [`119`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L119)

* [`158`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L158)

* [`167`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L167)

* [`173`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L173)

* [`178`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L178)

* [`204`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L204)

* [`231`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L231)

* [`242`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L242)

* [`274`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L274)

* [`309`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L309)

The most data loaded into the user's browser is at line [`274`](https://github.com/ivansg44/geem/blob/9fd02649597abd96973ddd868f5ab0c59b761a70/geem/views.py#L274), when the data inside the `@context` field of a package is loaded to check for substitution prefixes.