### PR TITLE
Add path and status of cart items to package

### DIFF
--- a/geem/fixtures/new_package_template.json
+++ b/geem/fixtures/new_package_template.json
@@ -24,7 +24,8 @@
                 "versionIRI": "api/resources/@file_base_name.@version.json",
                 "description": ""
             },
-            "specifications": {}
+            "specifications": {},
+            "customization": {}
         }
     }
 }

--- a/geem/static/geem/js/geem_form.js
+++ b/geem/static/geem/js/geem_form.js
@@ -1207,6 +1207,10 @@ function check_entity_id_change(resource_callback = null, entity_callback = null
 
 
 	if (!entityId) {
+		derender_entity_form();
+		reset_specification_tab();
+		top.focusEntityId = null;
+		$('a[href$="panelContent"]').click();
 		console.log("Couldn't find " + entityId) // No work to do here
 		return false
 	}

--- a/geem/static/geem/js/geem_portal.js
+++ b/geem/static/geem/js/geem_portal.js
@@ -112,6 +112,27 @@ function render_entity_form() {
 
 }
 
+
+/**
+ * De-render form view tab,
+ */
+function derender_entity_form() {
+	$('#mainForm').empty();
+	$('#formControls').empty();
+	$('#specificationSourceInfoBox').show();
+}
+
+
+/**
+ * Reset specifications tab.
+ */
+function reset_specification_tab() {
+	$('#specificationType')[0].selectedIndex = 0;
+	$('#dataSpecification').empty().hide();
+	$("#helpDataSpecification").show();
+}
+
+
 function portal_entity_form_callback(form) {
 	/* This is executed after a new form is rendered.
 	*/
@@ -120,12 +141,7 @@ function portal_entity_form_callback(form) {
 	render_entity_form_cart_icons(form) 
 
 	$('#specificationSourceInfoBox').hide()
-	// Clear out specification tab. Deselect specification menu.
-	$('#specificationType')[0].selectedIndex = 0
-	$('#dataSpecification').empty()
-	$('#specification-tabs li.is-active')
-		.removeClass('is-active')
-		.find('a').removeAttr('aria-selected'); // how else?
+	reset_specification_tab();
 
 	// Provide content area banner that shows selected entity
 	const entity = get_form_specification_component(form.entityId)

--- a/geem/static/geem/js/geem_resource.js
+++ b/geem/static/geem/js/geem_resource.js
@@ -51,7 +51,8 @@ function render_resource_form() {
 			$('#summary_name').attr('value', '');
 			$('#summary_description').empty();
 			$('#summary_file_base_name').attr('value', '');
-			$('#summary_public option[value="false"]').prop('selected', 'selected')
+			$('#summary_public option[value="false"]').prop('selected', 'selected');
+			$('#summary_curation option[value="draft"]').prop('selected', 'selected')
 		}
 
 		// Button logic

--- a/geem/static/geem/js/geem_resource.js
+++ b/geem/static/geem/js/geem_resource.js
@@ -108,7 +108,8 @@ function get_form_data(domId) {
 		'contents': {
 			'@context': 		{},
 			'specifications': 	{},
-			'metadata': 		{}
+			'metadata': 		{},
+			'customization':	{}
 		}
 	}
 

--- a/geem/static/geem/js/geem_specifications.js
+++ b/geem/static/geem/js/geem_specifications.js
@@ -31,7 +31,7 @@ function get_data_specification(report_type) {
 			entityId = path[0] // last item: path.length-1
 		}
 
-		$("#helpDataSpecification").remove()
+		$("#helpDataSpecification").hide();
 
 		switch (report_type) {
 

--- a/geem/utils.py
+++ b/geem/utils.py
@@ -34,7 +34,7 @@ def get_specifications(package, term_id=None):
 def delete_specifications(package, term_id=None):
     """Delete one or all specifications from ``package``.
 
-    :param package: queried package to get values from
+    :param package: queried package to delete values from
     :type package: django.db.models.query.QuerySet
     :param term_id: ID of term inside package specifications
     :type term_id: str
@@ -66,7 +66,7 @@ def delete_specifications(package, term_id=None):
 def create_specifications(package, term):
     """Add ``term`` to specifications of ``package``.
 
-    :param package: queried package to get values from
+    :param package: queried package to add values to
     :type package: django.db.models.query.QuerySet
     :param term: term to add to specifications
     :type term: dict
@@ -157,7 +157,7 @@ def delete_context(package, prefix=None):
 def create_context(package, prefix, iri):
     """Add ``prefix``-``iri`` pair to @context of ``package``.
 
-    :param package: queried package to delete values from
+    :param package: queried package to add values to
     :type package: django.db.models.query.QuerySet
     :param prefix: key added to ``package`` @context
     :type prefix: str

--- a/geem/utils.py
+++ b/geem/utils.py
@@ -189,6 +189,31 @@ def create_context(package, prefix, iri):
                        " id=%s" % (prefix, iri, package_id))
 
 
+def add_path_status_to_package(package, path, status):
+    """Add ``path``-``status`` pair to customization of ``package``.
+
+    :param package: queried package to add path and status to
+    :type package: django.db.models.query.QuerySet
+    :param path: key added to ``package`` customization
+    :type path: str
+    :param status: value added to ``package`` customization
+    :type status: str
+    :raises ValueError: Unable to add path and status somehow
+    """
+    if package.count() != 1:
+        raise ValueError('Please query an appropriate package')
+
+    package_id = package.values_list('id', flat=True)[0]
+
+    # Connect to the default database service
+    with connection.cursor() as cursor:
+        # See https://stackoverflow.com/a/23500670 for details on
+        # creation query used below.
+        cursor.execute("update geem_package set contents=(jsonb_set("
+                       "contents, '{customization, %s}', jsonb '\"%s\"')) "
+                       "where id=%s" % (path, status, package_id))
+
+
 def add_cart_item_to_package(cart_item_id, cart_item_package, target_package):
     """Add cart item and its children to package.
 

--- a/geem/views.py
+++ b/geem/views.py
@@ -298,9 +298,9 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
             # Add path and status of top-level cart item if it
             # succeeded in its addition to the target package.
             if response_data[cart_item_id]['status'] == 200:
-                utils.create_specifications(target_package, {
-                    'id': cart_item['path'], 'status': cart_item['status']
-                })
+                utils.add_path_status_to_package(
+                    target_package, cart_item['path'], cart_item['status']
+                )
 
         return Response(response_data, status=status.HTTP_200_OK)
 

--- a/geem/views.py
+++ b/geem/views.py
@@ -295,6 +295,13 @@ class ResourceViewSet(viewsets.ModelViewSet, mixins.CreateModelMixin, mixins.Des
                 utils.add_cart_item_to_package(cart_item_id, cart_item_package,
                                                target_package))
 
+            # Add path and status of top-level cart item if it
+            # succeeded in its addition to the target package.
+            if response_data[cart_item_id]['status'] == 200:
+                utils.create_specifications(target_package, {
+                    'id': cart_item['path'], 'status': cart_item['status']
+                })
+
         return Response(response_data, status=status.HTTP_200_OK)
 
     def create(self, request, pk=None):


### PR DESCRIPTION
* The cart items selected by the user--not including the items that are
  add recursively later--are added to specifications as a term
  additional to the term added detailing their entity attributes

* Path is used as the key for this additional term

* Status of the cart item is an attribute for this term